### PR TITLE
Minor type fix

### DIFF
--- a/script/server
+++ b/script/server
@@ -77,7 +77,7 @@ ENV["RAILS_ENV"] = options[:environment]
 RAILS_ENV.replace(options[:environment]) if defined?(RAILS_ENV)
 
 if File.exist?(options[:config])
-  config = options[:config]
+  config = options[:config].to_s
   if config =~ /\.ru$/
     cfgfile = File.read(config)
     if cfgfile[/^#\\(.*)/]


### PR DESCRIPTION
Original version resulted in
=> Rails 2.3.18 application starting on http://0.0.0.0:2500
/home/s/instiki-svn/script/server:81:in `<top (required)>': undefined method `=~' for #<Pathname:/home/s/instiki-svn/config.ru> (NoMethodError)
	from ./instiki:6:in `load'
	from ./instiki:6:in `<main>'