### PR TITLE
Atom feed for changes in XHTML diff form

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -199,7 +199,7 @@ class ApplicationController < ActionController::Base
 
   def set_content_type_header
     response.charset = 'utf-8'
-    if %w(atom_with_content atom_with_headlines).include?(action_name)
+    if %w(atom_with_content atom_with_headlines atom_with_changes).include?(action_name)
       response.content_type = Mime::ATOM
     elsif %w(tex tex_list).include?(action_name)
       response.content_type = Mime::TEXT
@@ -246,7 +246,7 @@ class ApplicationController < ActionController::Base
   end
   
   def authorization_needed?
-    not %w(login authenticate feeds published atom_with_headlines atom_with_content file blahtex_png).include?(action_name)
+    not %w(login authenticate feeds published atom_with_headlines atom_with_content atom_with_changes file blahtex_png).include?(action_name)
   end
 
   def authorized?

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -5,4 +5,9 @@ class Revision < ActiveRecord::Base
   def content
     read_attribute(:content).as_utf8
   end
+
+  def number
+    hash = Hash[self.page.revisions.map.with_index.to_a]
+    return hash[self] + 1
+  end
 end

--- a/app/models/web.rb
+++ b/app/models/web.rb
@@ -126,6 +126,10 @@ class Web < ActiveRecord::Base
     end
   end
 
+  def revisions_by_date
+    revisions.all(:order  => "revised_at")
+  end
+
   # OPTIMIZE Use the +delete_all+ with conditions for extra efficiency
   def remove_pages(pages_to_be_removed)
     pages_to_be_removed.each { |p| p.destroy }

--- a/app/views/wiki/atom_changes.rxml
+++ b/app/views/wiki/atom_changes.rxml
@@ -1,0 +1,36 @@
+xml.feed('xmlns' => "http://www.w3.org/2005/Atom", "xml:lang" => 'en') do
+  styles = { 'del.diffdel' => 'background-color:#FAA; text-decoration:line-through;', 'del.diffmod' => 'background-color:#FAA; text-decoration:line-through; border: 2px solid #FE0;', 'ins.diffins' => 'background-color:#AFA; text-decoration:underline;', 'ins.diffins' => 'background-color:#AFA; text-decoration:underline; border: 2px solid #FE0;' }
+  xml.title(@web.name + ' Changes')
+  xml.link( 'rel' => 'alternate', 'type' => "application/xhtml+xml", 'href' =>  url_for(:only_path => false, :web => @web_name, :action => @link_action, :id => 'HomePage') )
+  xml.link( 'rel' => 'self', 'href' =>  url_for(:only_path => false, :web => @web_name, :action => :atom_with_changes) )
+  xml.updated(@web.revised_at.getgm.strftime("%Y-%m-%dT%H:%M:%SZ") )
+  xml.id('tag:' + url_for(:only_path => false, :web => @web_name).split('/')[2].split(':')[0] + ',' + @web.created_at.getgm.strftime("%Y-%m-%d") + ':' + CGI.escape(@web.name) + '/changes' )
+  xml.subtitle('An Instiki Wiki')
+  xml.generator('Instiki', 'uri' => "http://golem.ph.utexas.edu/instiki/show/HomePage", 'version' => Instiki::VERSION::STRING)
+
+  for revision in @revisions
+    xml.entry do
+      if revision.number > 1
+        xml.title("%s (Revision %d)" % [ revision.page.plain_name, revision.number ])
+      else
+        xml.title(revision.page.plain_name)
+      end
+      xml.link('rel' => 'alternate', 'type' => 'application/xhtml+xml', 'href' => url_for(:only_path => false, :web => @web_name, :action => 'revision', :mode => 'diff', :id => revision.page.name, :rev => revision.number.to_s))
+      xml.updated(revision.revised_at.getgm.strftime("%Y-%m-%dT%H:%M:%SZ") )
+      xml.published(revision.created_at.getgm.strftime("%Y-%m-%dT%H:%M:%SZ") )
+      xml.id('tag:' +url_for(:only_path => false, :web => @web_name).split('/')[2].split(':')[0]  + ',' + revision.created_at.getgm.strftime("%Y-%m-%d") + ':' + CGI.escape(@web.name) + '/revision/' + revision.id.to_s + '/' + CGI.escape(revision.page.name) + '/' + revision.number.to_s)
+      xml.author do
+        xml.name(revision.author)
+      end
+      xml.content('type' => 'xhtml', 'xml:base' => url_for(:only_path => false, :web => @web_name, :action => @link_action, :id => revision.page.name) ) do
+        xml.div('xmlns' => 'http://www.w3.org/1999/xhtml' ) do
+          xml.p('%s on %s by %s %s.' % [ (revision.number > 1) ? "Revised" : "Created", format_date(revision.revised_at), revision.author, revision.author.respond_to?(:ip) ? "(%s)" % revision.author.ip.to_s : "" ])
+          if revision.number > 1
+            xml.p << ' Changes are formatted as follows: <ins class="diffins" style="%s">Added</ins> | <del class="diffdel" style="%s">Removed</del> | <del class="diffmod" style="%s">Chan</del><ins class="diffmod" style="%s">ged</ins>' % [ styles['ins.diffins'], styles['del.diffdel'], styles['del.diffmod'], styles['ins.diffmod'] ]
+          end
+          xml.div << PageRenderer.new(revision).display_diff(styles)
+        end
+      end
+    end
+  end
+end

--- a/app/views/wiki/feeds.rhtml
+++ b/app/views/wiki/feeds.rhtml
@@ -11,4 +11,9 @@
   <li>
     <%= link_to 'Headlines (Atom 1.0)', :web => @web.address, :action => :atom_with_headlines %>
   </li>
+ <%- if @rss_with_content_allowed -%>
+  <li>
+      <%= link_to 'Changes (Atom 1.0)', :web => @web.address, :action => :atom_with_changes %>
+  </li>
+ <%- end -%>
 </ul>

--- a/lib/page_renderer.rb
+++ b/lib/page_renderer.rb
@@ -37,7 +37,7 @@ class PageRenderer
     @display_published ||= render(:mode => :publish)
   end
 
-  def display_diff
+  def display_diff(styles = {})
     previous_revision = @revision.page.previous_revision(@revision)
     if previous_revision
 
@@ -47,7 +47,7 @@ class PageRenderer
       div = REXML::Element.new('div', nil, {:respect_whitespace =>:all})
       div.attributes['class'] = 'xhtmldiff_wrapper'
       diff_doc << div
-      hd = XHTMLDiff.new(div)
+      hd = XHTMLDiff.new(div, styles)
 
       parsed_previous_revision = REXML::HashableElementDelegator.new(
            REXML::XPath.first(REXML::Document.new(previous_content), '/div'))

--- a/test/functional/application_test.rb
+++ b/test/functional/application_test.rb
@@ -59,6 +59,11 @@ class ApplicationTest < ActionController::TestCase
     assert_equal 'application/atom+xml; charset=utf-8', @response.headers['Content-Type']
   end
   
+  def test_atom_mime_type_changes
+    get :atom_with_changes, :web => 'wiki1'
+    assert_equal 'application/atom+xml; charset=utf-8', @response.headers['Content-Type']
+  end
+
   def test_connect_to_model_unknown_wiki
     get :show, :web => 'unknown_wiki', :id => 'HomePage'
     assert_response :missing

--- a/test/functional/wiki_controller_test.rb
+++ b/test/functional/wiki_controller_test.rb
@@ -674,6 +674,33 @@ class WikiControllerTest < ActionController::TestCase
                :content => Time.now.getgm.strftime("%Y-%m-%dT%H:%M:%SZ")
   end
   
+  def test_atom_with_changes
+    r = process 'atom_with_changes', 'web' => 'wiki1'
+
+    assert_response(:success)
+    revisions = r.template_objects['revisions']
+    assert_equal [ revisions(:elephant_first_revision),
+                   revisions(:liquor_first_revision),
+                   revisions(:oak_first_revision),
+                   revisions(:no_wiki_word_first_revision),
+                   revisions(:that_way_first_revision),
+                   revisions(:smart_engine_first_revision),
+                   revisions(:my_way_first_revision),
+                   revisions(:first_page_first_revision),
+                   revisions(:home_page_second_revision),
+                   revisions(:home_page_first_revision) ], revisions,
+                 "Revisions are not as expected: #{revisions.map {|r| r.id}.inspect}"
+    assert !r.template_objects['hide_description']
+  end
+
+  def test_atom_with_changes_when_blocked
+    @web.update_attributes(:password => 'aaa', :published => false)
+    @web = Web.find(@web.id)
+
+    r = process 'atom_with_changes', 'web' => 'wiki1'
+    assert_equal 403, r.response_code
+  end
+
   def test_save
     r = process 'save', 'web' => 'wiki1', 'id' => 'NewPage', 'content' => 'Contents of a new page', 
       'author' => 'AuthorOfNewPage'

--- a/vendor/plugins/xhtmldiff/lib/xhtmldiff.rb
+++ b/vendor/plugins/xhtmldiff/lib/xhtmldiff.rb
@@ -61,21 +61,21 @@ class XHTMLDiff
 
 	class << self
 		BLOCK_CONTAINERS = ['div', 'ul', 'li']
-		def diff(a, b)
+		def diff(a, b, styles = {})
 			if a == b
 				return a.deep_clone
 			end
 			if REXML::HashableElementDelegator === a and REXML::HashableElementDelegator === b and a.name == b.name
 				o = REXML::Element.new(a.name)
 				o.add_attributes  a.attributes
-				hd = self.new(o)
+				hd = self.new(o, styles)
 				Diff::LCS.traverse_balanced(a, b, hd)
 				o
 			elsif REXML::Text === a and REXML::Text === b
 				o = REXML::Element.new('span')
 				aa = a.value.split(/\s/)
 				ba = b.value.split(/\s/)
-				hd = XHTMLTextDiff.new(o)
+				hd = XHTMLTextDiff.new(o, styles)
 				Diff::LCS.traverse_balanced(aa, ba, hd)
 				o
 			else
@@ -85,11 +85,12 @@ class XHTMLDiff
 	end
 
 	def diff(a, b)
-		self.class.diff(a,b)
+		self.class.diff(a,b,@styles)
 	end
 
-  def initialize(output)
+  def initialize(output, styles = {})
     @output = output
+    @styles = styles
   end
 
     # This will be called with both elements are the same
@@ -134,6 +135,10 @@ class XHTMLDiff
                 if class_name
                    el.add_attribute('class', class_name)
                 end
+                style = @styles[tag + '.' + class_name]
+                if style
+                   el.add_attribute('style', style)
+                end
 		el
 	end
 
@@ -165,6 +170,10 @@ class XHTMLDiff
                         wrapper_element.add_text element
                         if class_name
                            wrapper_element.add_attribute('class', class_name)
+                        end
+                        style = @styles[tag + '.' + class_name]
+                        if style
+                          wrapper_element.add_attribute('style', style)
                         end
                         wrapper_element
 		end


### PR DESCRIPTION
I added a new Changes Atom feed which includes XHTML diffs of each page revision. Previously, the Headlines and Full content feeds just showed the current state of each page, rather than the changes. Note that some feed readers may not style the differences properly because they strip out certain CSS styles (ideally, additions should be in green and removals should be in red with strikethrough text, just as on the web version).