### PR TITLE
Expire cached changes feeds

### DIFF
--- a/app/controllers/cache_sweeping_helper.rb
+++ b/app/controllers/cache_sweeping_helper.rb
@@ -16,7 +16,7 @@ module CacheSweepingHelper
       end
     end
 
-    %w(authors atom_with_content atom_with_headlines file_list).each do |action|
+    %w(authors atom_with_content atom_with_headlines atom_with_changes file_list).each do |action|
       expire_action :controller => 'wiki', :web => web.address, :action => action
     end
     


### PR DESCRIPTION
The new Atom feeds for changes should be expired along with the others.